### PR TITLE
Add control-flow context to LLM prompt to reduce false-positive risks

### DIFF
--- a/src/explain/ast-diff.ts
+++ b/src/explain/ast-diff.ts
@@ -3,6 +3,7 @@ import { FileDiff, FileAnalysis, StructuralChange } from "./types";
 import { extractDeclarationsGeneric } from "./generic-extractor";
 import { getConfigForExtension } from "./language-configs";
 import { hasLanguageForExt } from "../parsing/parser";
+import { extractControlFlow, parseChangedLines } from "./control-flow";
 
 export function analyzeFile(diff: FileDiff): FileAnalysis {
   const ext = path.extname(diff.path);
@@ -16,6 +17,7 @@ export function analyzeFile(diff: FileDiff): FileAnalysis {
       status: diff.status,
       language: null,
       structuralChanges: [],
+      controlFlowAnnotations: [],
       baseDeclarations: [],
       recentHistory: [],
       rawDiff: diff.hunks,
@@ -92,11 +94,17 @@ export function analyzeFile(diff: FileDiff): FileAnalysis {
     }
   }
 
+  const changedLines = parseChangedLines(diff.hunks);
+  const controlFlowAnnotations = diff.newContent
+    ? extractControlFlow(diff.newContent, ext, changedLines)
+    : [];
+
   return {
     path: diff.path,
     status: diff.status,
     language,
     structuralChanges,
+    controlFlowAnnotations,
     baseDeclarations,
     recentHistory: [],
     rawDiff: diff.hunks,

--- a/src/explain/control-flow.ts
+++ b/src/explain/control-flow.ts
@@ -1,0 +1,216 @@
+import type { SyntaxNode } from "../parsing/parser";
+import { parseSource, hasLanguageForExt } from "../parsing/parser";
+import { ControlFlowAnnotation } from "./types";
+
+/**
+ * Parse unified diff hunks to extract the set of changed line numbers
+ * on the new side of the diff.
+ */
+export function parseChangedLines(hunks: string): Set<number> {
+  const lines = new Set<number>();
+  let currentLine = 0;
+
+  for (const line of hunks.split("\n")) {
+    const hunkHeader = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkHeader) {
+      currentLine = parseInt(hunkHeader[1], 10);
+      continue;
+    }
+
+    if (currentLine === 0) continue;
+
+    if (line.startsWith("+")) {
+      lines.add(currentLine);
+      currentLine++;
+    } else if (line.startsWith("-")) {
+      // Deleted lines don't advance the new-side line counter
+    } else {
+      // Context line
+      currentLine++;
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Extract control-flow annotations for functions that contain changed lines.
+ * Detects guard patterns (if-return/throw before operations) and try-catch blocks.
+ */
+export function extractControlFlow(
+  source: string,
+  ext: string,
+  changedLines: Set<number>,
+): ControlFlowAnnotation[] {
+  if (!source.trim() || changedLines.size === 0) return [];
+  if (!hasLanguageForExt(ext)) return [];
+
+  let tree;
+  try {
+    const result = parseSource(source, ext);
+    tree = result.tree;
+  } catch {
+    return [];
+  }
+
+  const annotations: ControlFlowAnnotation[] = [];
+  findFunctionsWithChanges(tree.rootNode, changedLines, annotations);
+  return annotations;
+}
+
+/** Recursively find function-like nodes that contain changed lines */
+function findFunctionsWithChanges(
+  node: SyntaxNode,
+  changedLines: Set<number>,
+  annotations: ControlFlowAnnotation[],
+): void {
+  const funcName = getFunctionName(node);
+  if (funcName !== null) {
+    // This is a function-like node — check if it contains changed lines
+    const startLine = node.startPosition.row + 1;
+    const endLine = node.endPosition.row + 1;
+    let hasChanges = false;
+    for (const line of changedLines) {
+      if (line >= startLine && line <= endLine) {
+        hasChanges = true;
+        break;
+      }
+    }
+
+    if (hasChanges) {
+      analyzeFunction(node, funcName, changedLines, annotations);
+    }
+    // Don't recurse into nested functions — analyze them separately
+  }
+
+  // Recurse into children to find nested functions and top-level functions
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i)!;
+    if (getFunctionName(child) !== null) {
+      findFunctionsWithChanges(child, changedLines, annotations);
+    } else {
+      findFunctionsWithChanges(child, changedLines, annotations);
+    }
+  }
+}
+
+/** Get the name of a function-like node, or null if not a function */
+function getFunctionName(node: SyntaxNode): string | null {
+  const funcTypes = new Set([
+    "function_declaration",
+    "function_definition",
+    "method_definition",
+    "method_declaration",
+    "function_item",       // Rust
+    "arrow_function",
+  ]);
+
+  if (!funcTypes.has(node.type)) return null;
+
+  // Direct name field
+  const name = node.childForFieldName("name")?.text;
+  if (name) return name;
+
+  // Arrow functions assigned to a variable: const foo = () => ...
+  if (node.type === "arrow_function" && node.parent?.type === "variable_declarator") {
+    return node.parent.childForFieldName("name")?.text || null;
+  }
+
+  return "<anonymous>";
+}
+
+/** Analyze a single function for guard patterns and try-catch blocks */
+function analyzeFunction(
+  funcNode: SyntaxNode,
+  funcName: string,
+  changedLines: Set<number>,
+  annotations: ControlFlowAnnotation[],
+): void {
+  const body = funcNode.childForFieldName("body");
+  if (!body) return;
+
+  // Walk direct children of the function body for guards and try-catch
+  for (let i = 0; i < body.childCount; i++) {
+    const stmt = body.child(i)!;
+
+    if (stmt.type === "if_statement") {
+      const guard = detectGuard(stmt);
+      if (guard) {
+        annotations.push({
+          functionName: funcName,
+          line: stmt.startPosition.row + 1,
+          kind: "guard",
+          description: guard,
+        });
+      }
+    }
+
+    if (stmt.type === "try_statement") {
+      const tryLine = stmt.startPosition.row + 1;
+      const tryEnd = stmt.endPosition.row + 1;
+      let coversChanges = false;
+      for (const line of changedLines) {
+        if (line >= tryLine && line <= tryEnd) {
+          coversChanges = true;
+          break;
+        }
+      }
+      if (coversChanges) {
+        annotations.push({
+          functionName: funcName,
+          line: tryLine,
+          kind: "try-catch",
+          description: "operations wrapped in try-catch",
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Detect if an if-statement is a guard pattern.
+ * A guard is: if (condition) { return/throw/process.exit }
+ * Returns a human-readable description, or null if not a guard.
+ */
+function detectGuard(ifNode: SyntaxNode): string | null {
+  const consequence = ifNode.childForFieldName("consequence");
+  if (!consequence) return null;
+
+  // Check if the consequence contains a return, throw, or process.exit
+  if (!containsEarlyExit(consequence)) return null;
+
+  // Extract a readable condition description
+  const condition = ifNode.childForFieldName("condition");
+  if (!condition) return null;
+
+  const condText = condition.text;
+
+  // Keep it short — truncate long conditions
+  const shortCond = condText.length > 80
+    ? condText.slice(0, 77) + "..."
+    : condText;
+
+  return `returns/exits early if ${shortCond}`;
+}
+
+/** Check if a block contains a return, throw, or process.exit statement */
+function containsEarlyExit(node: SyntaxNode): boolean {
+  if (node.type === "return_statement" || node.type === "throw_statement") {
+    return true;
+  }
+
+  // process.exit(...)
+  if (node.type === "expression_statement") {
+    const expr = node.child(0);
+    if (expr?.type === "call_expression") {
+      const callee = expr.childForFieldName("function")?.text;
+      if (callee === "process.exit") return true;
+    }
+  }
+
+  for (let i = 0; i < node.childCount; i++) {
+    if (containsEarlyExit(node.child(i)!)) return true;
+  }
+
+  return false;
+}

--- a/src/explain/types.ts
+++ b/src/explain/types.ts
@@ -31,11 +31,19 @@ export interface StructuralChange {
   detail?: string;
 }
 
+export interface ControlFlowAnnotation {
+  functionName: string;
+  line: number;
+  kind: "guard" | "try-catch";
+  description: string;
+}
+
 export interface FileAnalysis {
   path: string;
   status: FileStatus;
   language: string | null;
   structuralChanges: StructuralChange[];
+  controlFlowAnnotations: ControlFlowAnnotation[];
   baseDeclarations: string[];
   recentHistory: FileHistoryEntry[];
   rawDiff: string;

--- a/test/unit/control-flow.test.ts
+++ b/test/unit/control-flow.test.ts
@@ -1,0 +1,180 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseChangedLines, extractControlFlow } from "../../src/explain/control-flow";
+
+describe("parseChangedLines", () => {
+  it("should extract added line numbers from a hunk", () => {
+    const hunks = `@@ -0,0 +1,5 @@
++line one
++line two
++line three
++line four
++line five`;
+    const lines = parseChangedLines(hunks);
+    assert.deepEqual([...lines].sort((a, b) => a - b), [1, 2, 3, 4, 5]);
+  });
+
+  it("should handle mixed additions, deletions, and context lines", () => {
+    const hunks = `@@ -10,6 +10,7 @@
+ context line
+-deleted line
++added line
++another added line
+ context line
+ more context`;
+    const lines = parseChangedLines(hunks);
+    // Line 10 = context (no change), deleted doesn't advance,
+    // line 11 = added, line 12 = added, line 13 = context, line 14 = context
+    assert.deepEqual([...lines].sort((a, b) => a - b), [11, 12]);
+  });
+
+  it("should handle multiple hunks", () => {
+    const hunks = `@@ -1,3 +1,4 @@
+ context
++added at line 2
+ context
+@@ -10,3 +11,4 @@
+ context
++added at line 12
+ context`;
+    const lines = parseChangedLines(hunks);
+    assert.ok(lines.has(2));
+    assert.ok(lines.has(12));
+    assert.equal(lines.size, 2);
+  });
+
+  it("should return empty set for empty hunks", () => {
+    const lines = parseChangedLines("");
+    assert.equal(lines.size, 0);
+  });
+});
+
+describe("extractControlFlow", () => {
+  it("should detect if-return guard in a function", () => {
+    const source = `
+function run() {
+  if (fs.existsSync(path)) {
+    console.error("already exists");
+    return 1;
+  }
+  fs.writeFileSync(path, data);
+  return 0;
+}`;
+    // All lines are "changed"
+    const changedLines = new Set([2, 3, 4, 5, 6, 7, 8, 9]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    assert.equal(annotations.length, 1);
+    assert.equal(annotations[0].kind, "guard");
+    assert.equal(annotations[0].functionName, "run");
+    assert.ok(annotations[0].description.includes("existsSync"));
+  });
+
+  it("should detect if-throw guard", () => {
+    const source = `
+function validate(input: string) {
+  if (!input) {
+    throw new Error("missing input");
+  }
+  return process(input);
+}`;
+    const changedLines = new Set([2, 3, 4, 5, 6]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    assert.equal(annotations.length, 1);
+    assert.equal(annotations[0].kind, "guard");
+    assert.ok(annotations[0].description.includes("!input"));
+  });
+
+  it("should detect try-catch around changed lines", () => {
+    const source = `
+function doWork() {
+  try {
+    riskyOperation();
+  } catch (err) {
+    console.error(err);
+  }
+}`;
+    const changedLines = new Set([3, 4]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    assert.equal(annotations.length, 1);
+    assert.equal(annotations[0].kind, "try-catch");
+    assert.equal(annotations[0].functionName, "doWork");
+  });
+
+  it("should not produce annotations when no changed lines are in the function", () => {
+    const source = `
+function guarded() {
+  if (exists) {
+    return;
+  }
+  doStuff();
+}`;
+    // Changed lines are outside this function
+    const changedLines = new Set([20, 21, 22]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    assert.equal(annotations.length, 0);
+  });
+
+  it("should not flag if-statements without early exit as guards", () => {
+    const source = `
+function example() {
+  if (condition) {
+    console.log("hello");
+  }
+  doStuff();
+}`;
+    const changedLines = new Set([2, 3, 4, 5, 6]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    assert.equal(annotations.length, 0);
+  });
+
+  it("should return empty for non-parseable extensions", () => {
+    const source = "some random content";
+    const changedLines = new Set([1]);
+    const annotations = extractControlFlow(source, ".xyz", changedLines);
+    assert.equal(annotations.length, 0);
+  });
+
+  it("should return empty for empty source", () => {
+    const annotations = extractControlFlow("", ".ts", new Set([1]));
+    assert.equal(annotations.length, 0);
+  });
+
+  it("should return empty for empty changed lines", () => {
+    const source = `function foo() { return 1; }`;
+    const annotations = extractControlFlow(source, ".ts", new Set());
+    assert.equal(annotations.length, 0);
+  });
+
+  it("should detect guard with process.exit", () => {
+    const source = `
+function main() {
+  if (!config) {
+    console.error("no config");
+    process.exit(1);
+  }
+  startServer(config);
+}`;
+    const changedLines = new Set([2, 3, 4, 5, 6, 7]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    assert.equal(annotations.length, 1);
+    assert.equal(annotations[0].kind, "guard");
+    assert.ok(annotations[0].description.includes("!config"));
+  });
+
+  it("should detect multiple guards in a single function", () => {
+    const source = `
+function init() {
+  if (fs.existsSync(file)) {
+    return 1;
+  }
+  if (!isValid(input)) {
+    throw new Error("invalid");
+  }
+  doWork();
+}`;
+    const changedLines = new Set([2, 3, 4, 5, 6, 7, 8, 9]);
+    const annotations = extractControlFlow(source, ".ts", changedLines);
+    const guards = annotations.filter((a) => a.kind === "guard");
+    assert.equal(guards.length, 2);
+  });
+});

--- a/test/unit/markdown-summary.test.ts
+++ b/test/unit/markdown-summary.test.ts
@@ -37,6 +37,7 @@ function makeReport(overrides: Partial<ExplainReport> = {}): ExplainReport {
         structuralChanges: [
           { file: "src/auth.ts", type: "function", action: "modified", name: "validateToken" },
         ],
+        controlFlowAnnotations: [],
         baseDeclarations: ["validateToken (function)"],
         recentHistory: [],
         rawDiff: "",


### PR DESCRIPTION
The LLM was flagging guarded operations as risks (e.g. "overwrites file" when an existsSync guard prevents it). This adds AST-based control-flow analysis that detects guard patterns (if-return/throw/exit) and try-catch blocks in changed functions, and includes them in the prompt so the LLM can reason about safety checks.